### PR TITLE
Fix reference to aws-systems-manager module

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -78,8 +78,8 @@ module "aws-three-tier-loadbalancer" {
   internal_lb_subnets           = module.aws-three-tier-network.subnets_app_tier
 }
 
-module "aws-session-manager" {
-  source           = "./modules/aws-session-manager"
+module "aws-systems-manager" {
+  source           = "./modules/aws-systems-manager"
   iam_policy_level = "group"
   create_iam_group = false
   iam_group_name   = "admins"

--- a/output.tf
+++ b/output.tf
@@ -9,7 +9,7 @@ output "external_lb_endpoint" {
 }
 
 output "initial_iam_user_password" {
-  value       = module.aws-session-manager.initial_iam_user_password == [] ? null : module.aws-session-manager.initial_iam_user_password[0]
+  value       = module.aws-systems-manager.initial_iam_user_password == [] ? null : module.aws-systems-manager.initial_iam_user_password[0]
   description = "Initial password of created IAM user (encrypted)"
   sensitive   = false
 }


### PR DESCRIPTION
Fix reference to aws-systems-manager module in `main.tf` and `output.tf`.